### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -6,6 +6,9 @@ License: GPLv2.  See COPYING for details.
 Downloads:  https://sourceforge.net/projects/cpuminer/files/
 Git tree:   https://github.com/pooler/cpuminer
 
+Dependencies on Ubuntu 18.04:
+	sudo apt-get install automake libtool build-essential libcurl4-openssl-dev libcurl4-gnutls-dev
+
 Dependencies:
 	libcurl			http://curl.haxx.se/libcurl/
 	jansson			http://www.digip.org/jansson/


### PR DESCRIPTION
I build de project only after install this packages on Ubuntu 18.04

sudo apt-get install automake libtool build-essential libcurl4-openssl-dev libcurl4-gnutls-dev